### PR TITLE
fix: EP-4404 - emit empty-package structMap/div in METS namespace

### DIFF
--- a/Eplicta.Mets.Tests/MetsValidatorTests.cs
+++ b/Eplicta.Mets.Tests/MetsValidatorTests.cs
@@ -73,6 +73,29 @@ public class MetsValidatorTests
         result.Should().BeEmpty();
     }
 
+    [Theory]
+    [ClassData(typeof(MetsVersionGenerator))]
+    public void Empty_package_has_no_structMap_div_namespace_error(ModsVersion version)
+    {
+        // EP-4404: an empty package (no files, no sources) previously emitted the structMap's child as
+        // <div xmlns=""> (empty namespace), which the METS XSD rejects ("invalid child element 'div'").
+        // Mirrors Minimal but without AddFile, so it takes the empty-package branch.
+        var modsData = new Builder()
+            .AddAltRecord(new MetsData.AltRecord())
+            .AddAltRecord(new MetsData.AltRecord())
+            .AddAltRecord(new MetsData.AltRecord())
+            .AddMetsAttributes([new MetsData.MetsAttribute { Name = MetsData.EMetsAttributeName.ObjId, Value = string.Empty }])
+            .Build();
+        var document = new Renderer(modsData).Render();
+        var sut = new MetsValidator();
+
+        //Act
+        var result = sut.Validate(document, version, MetsSchema.Default);
+
+        //Assert
+        result.Should().BeEmpty();
+    }
+
     class MetsVersionGenerator : IEnumerable<object[]>
     {
         public IEnumerator<object[]> GetEnumerator()

--- a/Eplicta.Mets.Tests/RendererTests.cs
+++ b/Eplicta.Mets.Tests/RendererTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Xml;
 using AutoFixture;
 using Eplicta.Mets.Entities;
 using FluentAssertions;
@@ -8,6 +9,28 @@ namespace Eplicta.Mets.Tests;
 
 public class RendererTests
 {
+    private const string MetsNs = "http://www.loc.gov/METS/";
+
+    [Fact]
+    public void Empty_package_emits_div_in_mets_namespace()
+    {
+        // EP-4404: a package with no files and no sources takes the "empty package" branch, which created
+        // the structMap's child <div> in the empty namespace instead of the METS namespace — breaking XSD
+        // validation. The div must live in http://www.loc.gov/METS/ like every other METS element.
+        var metsData = new Builder()
+            .AddMetsAttributes([new MetsData.MetsAttribute { Name = MetsData.EMetsAttributeName.ObjId, Value = string.Empty }])
+            .Build();
+        var document = new Renderer(metsData).Render(DateTime.MinValue);
+
+        var nsmgr = new XmlNamespaceManager(document.NameTable);
+        nsmgr.AddNamespace("mets", MetsNs);
+
+        // The empty-package structMap is the one carrying LABEL (the populated one uses TYPE="Package").
+        var div = document.SelectSingleNode("//mets:structMap[@LABEL]/mets:div", nsmgr);
+        div.Should().NotBeNull("the empty-package structMap <div> must be in the METS namespace");
+        div.NamespaceURI.Should().Be(MetsNs);
+    }
+
     private const string DefaultBuilderData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><mets:mets xmlns=\"http://www.loc.gov/METS/\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" OBJID=\"\" TYPE=\"SIP\" xmlns:mets=\"http://www.loc.gov/METS/\"><mets:metsHdr CREATEDATE=\"0001-01-01T00:00:00Z\"><mets:agent ROLE=\"CREATOR\" TYPE=\"INDIVIDUAL\" OTHERTYPE=\"SOFTWARE\"><mets:name></mets:name></mets:agent><mets:altRecordID></mets:altRecordID><mets:altRecordID></mets:altRecordID><mets:altRecordID></mets:altRecordID><mets:altRecordID TYPE=\"SUBMISSIONAGREEMENT\">OK</mets:altRecordID><mets:altRecordID>SIP</mets:altRecordID><mets:altRecordID>sip.xml</mets:altRecordID></mets:metsHdr><mets:fileSec><mets:fileGrp USE=\"FILES\"><mets:file ID=\"IDD41D8CD98F00B204E9800998ECF8427E\" USE=\"\" MIMETYPE=\"\" SIZE=\"0\" CREATED=\"0001-01-01T00:00:00Z\" CHECKSUM=\"1B2M2Y8AsgTpgAmY7PhCfg==\" CHECKSUMTYPE=\"MD5\"><mets:FLocat LOCTYPE=\"URL\" xlink:href=\"file:///\" xlink:type=\"simple\" /></mets:file></mets:fileGrp></mets:fileSec><mets:structMap TYPE=\"Package\"><mets:div TYPE=\"DataFiles\"><mets:fptr FILEID=\"IDD41D8CD98F00B204E9800998ECF8427E\" /></mets:div></mets:structMap></mets:mets>";
     private const string DefaultNewData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><mets xmlns=\"http://www.loc.gov/METS/\" xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" OBJID=\"\" TYPE=\"SIP\" ><metsHdr CREATEDATE=\"0001-01-01T00:00:00.0000000\" /><dmdSec ID=\"ID1\"><mdWrap MDTYPE=\"MODS\"><xmlData /></mdWrap></dmdSec><fileSec><fileGrp /></fileSec><structMap LABEL=\"No structmap defined in this information package\"><div /></structMap></mets>";
 

--- a/Eplicta.Mets/Renderer.cs
+++ b/Eplicta.Mets/Renderer.cs
@@ -322,7 +322,7 @@ public class Renderer
             structMap.SetAttribute("LABEL", "No structmap defined in this information package");
             root.AppendChild(structMap);
 
-            var div = doc.CreateElement("div");
+            var div = doc.CreateElement("mets", "div", MetsNs);
             structMap.AppendChild(div);
         }
         else


### PR DESCRIPTION
## EP-4404 - METS renderer emits structMap/div in empty namespace

### Problem
In `Eplicta.Mets/Renderer.cs`, the empty-package branch created the structMap's child `<div>` with no XML namespace (`doc.CreateElement("div")`), while its parent `structMap` lives in the METS namespace `http://www.loc.gov/METS/`. The METS XSD requires the `div` to be in the METS namespace, so an empty package (no files, no sources) failed validation with "invalid child element 'div'".

### Fix
One-line change: create the div in the METS namespace - `doc.CreateElement("mets", "div", MetsNs)` - so it matches every other METS element.

### Tests added
- `RendererTests.Empty_package_emits_div_in_mets_namespace` - asserts the empty-package structMap `<div>` is emitted in `http://www.loc.gov/METS/`.
- `MetsValidatorTests.Empty_package_has_no_structMap_div_namespace_error` - validates an empty package against the METS schema across all MODS versions and expects no errors.

### Scope
`Eplicta.Mets/Renderer.cs` (1 line) + 2 regression tests. No API changes.

Jira: https://eplicta.atlassian.net/browse/EP-4404