### PR TITLE
EP-4540: emit standard MODS mods:name creator (dual-emit) + deserialize

### DIFF
--- a/Eplicta.Mets.Tests/ModsNameTests.cs
+++ b/Eplicta.Mets.Tests/ModsNameTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Xml;
+using Eplicta.Mets.Entities;
+using FluentAssertions;
+using Xunit;
+
+namespace Eplicta.Mets.Tests;
+
+public class ModsNameTests
+{
+    private const string ModsNs = "http://www.loc.gov/mods/v3";
+    private const string DisplayName = "Uppsala Stadsarkiv";
+
+    private static MetsData BuildMetsDataWithCreator()
+    {
+        return new Builder()
+            .SetModsSection(new MetsData.ModsSectionData
+            {
+                Identifier = "test-identifier",
+                Creator = new MetsData.ModsName
+                {
+                    DisplayName = DisplayName,
+                    Type = MetsData.ENameType.Corporate
+                }
+            })
+            .AddAltRecord(new MetsData.AltRecord())
+            .AddAltRecord(new MetsData.AltRecord())
+            .AddAltRecord(new MetsData.AltRecord())
+            .AddMetsAttributes([new MetsData.MetsAttribute { Name = MetsData.EMetsAttributeName.ObjId, Value = string.Empty }])
+            .AddFile(new DataFileSource { Data = [] })
+            .Build();
+    }
+
+    private static XmlDocument RenderWithCreator()
+    {
+        return new Renderer(BuildMetsDataWithCreator()).Render(DateTime.MinValue);
+    }
+
+    [Fact]
+    public void Render_WhenCreatorIsNull_ShouldNotEmitModsNameElement()
+    {
+        //Arrange
+        var metsData = new Builder()
+            .SetModsSection(new MetsData.ModsSectionData
+            {
+                Identifier = "test-identifier",
+                Creator = null
+            })
+            .AddAltRecord(new MetsData.AltRecord())
+            .AddAltRecord(new MetsData.AltRecord())
+            .AddAltRecord(new MetsData.AltRecord())
+            .AddMetsAttributes([new MetsData.MetsAttribute { Name = MetsData.EMetsAttributeName.ObjId, Value = string.Empty }])
+            .AddFile(new DataFileSource { Data = [] })
+            .Build();
+        var document = new Renderer(metsData).Render(DateTime.MinValue);
+
+        //Act
+        var nsmgr = new XmlNamespaceManager(document.NameTable);
+        nsmgr.AddNamespace("mods", ModsNs);
+        var nameNode = document.SelectSingleNode("//mods:mods/mods:name", nsmgr);
+
+        //Assert
+        nameNode.Should().BeNull("mods:name must not be emitted when Creator is null");
+    }
+
+    [Fact]
+    public void Render_WhenCreatorIsSet_ShouldEmitModsDisplayFormWithCreatorDisplayName()
+    {
+        //Arrange
+        var document = RenderWithCreator();
+
+        //Act
+        var nsmgr = new XmlNamespaceManager(document.NameTable);
+        nsmgr.AddNamespace("mods", ModsNs);
+        var displayFormNode = document.SelectSingleNode("//mods:mods/mods:name/mods:displayForm", nsmgr);
+
+        //Assert
+        displayFormNode.Should().NotBeNull("mods:displayForm must be emitted inside mods:name");
+        displayFormNode.InnerText.Should().Be(DisplayName);
+    }
+
+    [Fact]
+    public void Render_WhenCreatorIsSet_ShouldEmitModsNamePartWithCreatorDisplayName()
+    {
+        //Arrange
+        var document = RenderWithCreator();
+
+        //Act
+        var nsmgr = new XmlNamespaceManager(document.NameTable);
+        nsmgr.AddNamespace("mods", ModsNs);
+        var namePartNode = document.SelectSingleNode("//mods:mods/mods:name/mods:namePart", nsmgr);
+
+        //Assert
+        namePartNode.Should().NotBeNull("mods:namePart must be emitted inside mods:name");
+        namePartNode.InnerText.Should().Be(DisplayName);
+    }
+
+    [Fact]
+    public void Render_WhenCreatorIsSet_ShouldEmitModsNameWithCorrectTypeAttribute()
+    {
+        //Arrange
+        var document = RenderWithCreator();
+
+        //Act
+        var nsmgr = new XmlNamespaceManager(document.NameTable);
+        nsmgr.AddNamespace("mods", ModsNs);
+        var nameNode = document.SelectSingleNode("//mods:mods/mods:name", nsmgr);
+
+        //Assert
+        nameNode.Should().NotBeNull("mods:name must be emitted when Creator is set");
+        var typeAttr = ((XmlElement)nameNode).GetAttribute("type");
+        typeAttr.Should().Be("corporate", "type attribute must be the lowercased ENameType value");
+    }
+
+    [Fact]
+    public void Render_WhenCreatorIsSet_ShouldEmitModsRoleTermWithCreatorText()
+    {
+        //Arrange
+        var document = RenderWithCreator();
+
+        //Act
+        var nsmgr = new XmlNamespaceManager(document.NameTable);
+        nsmgr.AddNamespace("mods", ModsNs);
+        var roleTermNode = document.SelectSingleNode("//mods:mods/mods:name/mods:role/mods:roleTerm", nsmgr);
+
+        //Assert
+        roleTermNode.Should().NotBeNull("mods:roleTerm must be emitted inside mods:role");
+        roleTermNode.InnerText.Should().Be("creator");
+        var el = (XmlElement)roleTermNode;
+        el.GetAttribute("type").Should().Be("text");
+        el.GetAttribute("authority").Should().Be("marcrelator");
+    }
+
+    [Fact]
+    public void Render_WhenCreatorIsSet_ShouldStillValidateAgainstFgsPublSchema()
+    {
+        //Arrange
+        var metsData = new Builder()
+            .SetModsSection(new MetsData.ModsSectionData
+            {
+                Identifier = "test-identifier",
+                Url = new Uri("http://example.com/doc"),
+                ModsTitle = "Test document",
+                Creator = new MetsData.ModsName
+                {
+                    DisplayName = DisplayName,
+                    Type = MetsData.ENameType.Corporate
+                }
+            })
+            .AddAltRecord(new MetsData.AltRecord())
+            .AddAltRecord(new MetsData.AltRecord())
+            .AddAltRecord(new MetsData.AltRecord())
+            .AddMetsAttributes([new MetsData.MetsAttribute { Name = MetsData.EMetsAttributeName.ObjId, Value = string.Empty }])
+            .AddFile(new DataFileSource { Data = [] })
+            .Build();
+        var document = new Renderer(metsData).Render(DateTime.MinValue);
+        var sut = new MetsValidator();
+
+        //Act
+        var result = sut.Validate(document, ModsVersion.ModsFgsPubl_1_0, MetsSchema.Default);
+
+        //Assert
+        result.Should().BeEmpty("a mods:name element must not break FGS-PUBL schema validation");
+    }
+
+    [Fact]
+    public void Deserialize_WhenDocumentContainsModsName_ShouldPopulateNamesArray()
+    {
+        //Arrange
+        var document = RenderWithCreator();
+        var sut = new Serializer();
+
+        //Act
+        var result = sut.Deserialize(document);
+
+        //Assert
+        var names = result.DmdSec.MdWrap.XmlData.Mods.Names;
+        names.Should().NotBeNullOrEmpty("Names must be populated when mods:name is present in the document");
+        names.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Deserialize_WhenDocumentContainsModsName_ShouldParseDisplayForm()
+    {
+        //Arrange
+        var document = RenderWithCreator();
+        var sut = new Serializer();
+
+        //Act
+        var result = sut.Deserialize(document);
+
+        //Assert
+        var name = result.DmdSec.MdWrap.XmlData.Mods.Names[0];
+        name.DisplayForm.Should().Be(DisplayName);
+    }
+
+    [Fact]
+    public void Deserialize_WhenDocumentContainsModsName_ShouldParseNamePart()
+    {
+        //Arrange
+        var document = RenderWithCreator();
+        var sut = new Serializer();
+
+        //Act
+        var result = sut.Deserialize(document);
+
+        //Assert
+        var name = result.DmdSec.MdWrap.XmlData.Mods.Names[0];
+        name.NamePart.Should().Be(DisplayName);
+    }
+
+    [Fact]
+    public void Deserialize_WhenDocumentContainsModsName_ShouldParseTypeAttribute()
+    {
+        //Arrange
+        var document = RenderWithCreator();
+        var sut = new Serializer();
+
+        //Act
+        var result = sut.Deserialize(document);
+
+        //Assert
+        var name = result.DmdSec.MdWrap.XmlData.Mods.Names[0];
+        name.Type.Should().Be("corporate");
+    }
+
+    [Fact]
+    public void Deserialize_WhenDocumentContainsModsName_ShouldParseRoleTerm()
+    {
+        //Arrange
+        var document = RenderWithCreator();
+        var sut = new Serializer();
+
+        //Act
+        var result = sut.Deserialize(document);
+
+        //Assert
+        var name = result.DmdSec.MdWrap.XmlData.Mods.Names[0];
+        // Assumption: ModsNameElement exposes the roleTerm inner text via a RoleTerm property
+        // (or a nested Role/RoleTerm element structure). The implementation must expose
+        // the "creator" string so that this assertion passes.
+        name.RoleTerm.Should().Be("creator");
+    }
+}

--- a/Eplicta.Mets.Tests/RendererValidatorTests.cs
+++ b/Eplicta.Mets.Tests/RendererValidatorTests.cs
@@ -29,6 +29,24 @@ public class RendererOfflineValidatorTests
 
     [Theory]
     [ClassData(typeof(SchemaGenerator))]
+    public void CreatorEmitsValidModsNameForAllSchemas(string format)
+    {
+        //Arrange
+        var modsData = new Fixture().Build<MetsData>().Without(x => x.MetsHdr).Without(x => x.Sources).Create();
+        modsData = modsData with { Mods = modsData.Mods with { Creator = new MetsData.ModsName { DisplayName = "Uppsala Stadsarkiv", Type = MetsData.ENameType.Corporate } } };
+        var document = new Renderer(modsData).Render();
+        var schema = Mets.Helpers.Resource.GetXml(format);
+        var sut = new XmlValidatorOffline();
+
+        //Act
+        var result = sut.Validate(document, schema);
+
+        //Assert
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [ClassData(typeof(SchemaGenerator))]
     public void Minimal(string format)
     {
         //Arrange

--- a/Eplicta.Mets/Entities/DeserializedMets.cs
+++ b/Eplicta.Mets/Entities/DeserializedMets.cs
@@ -94,6 +94,9 @@ public record DeserializedMets
                     [XmlElement(ElementName = "note", Namespace = "http://www.loc.gov/mods/v3")]
                     public ModsNoteElement[] Notes { get; set; }
 
+                    [XmlElement(ElementName = "name", Namespace = "http://www.loc.gov/mods/v3")]
+                    public ModsNameElement[] Names { get; set; }
+
                     public record ModsIdentifierElement : XmlValueElement<string>
                     {
                         [XmlAttribute("type")]
@@ -222,6 +225,39 @@ public record DeserializedMets
     {
         [XmlAttribute("type")]
         public string Type { get; set; }
+    }
+
+    public record ModsNameElement
+    {
+        [XmlAttribute("type")]
+        public string Type { get; set; }
+
+        [XmlElement(ElementName = "namePart", Namespace = "http://www.loc.gov/mods/v3")]
+        public string NamePart { get; set; }
+
+        [XmlElement(ElementName = "displayForm", Namespace = "http://www.loc.gov/mods/v3")]
+        public string DisplayForm { get; set; }
+
+        [XmlElement(ElementName = "role", Namespace = "http://www.loc.gov/mods/v3")]
+        public ModsRoleElement Role { get; set; }
+
+        [XmlIgnore]
+        public string RoleTerm => Role?.RoleTerm?.Value;
+
+        public record ModsRoleElement
+        {
+            [XmlElement(ElementName = "roleTerm", Namespace = "http://www.loc.gov/mods/v3")]
+            public ModsRoleTermElement RoleTerm { get; set; }
+        }
+
+        public record ModsRoleTermElement : XmlValueElement<string>
+        {
+            [XmlAttribute("type")]
+            public string Type { get; set; }
+
+            [XmlAttribute("authority")]
+            public string Authority { get; set; }
+        }
     }
 }
 

--- a/Eplicta.Mets/Entities/MetsData.cs
+++ b/Eplicta.Mets/Entities/MetsData.cs
@@ -91,6 +91,12 @@ public record MetsData
         ObjId
     }
 
+    public enum ENameType
+    {
+        Personal,
+        Corporate
+    }
+
     public MetsHdrData MetsHdr { get; set; }
     public AgentData[] Agents { get; set; }
     //public CompanyData Company { get; set; }
@@ -147,6 +153,12 @@ public record MetsData
         public string Href { get; set; }
     }
 
+    public record ModsName
+    {
+        public string DisplayName { get; set; }
+        public ENameType Type { get; set; }
+    }
+
     public record ModsSectionData
     {
         public string Xmlns { get; set; }
@@ -160,6 +172,7 @@ public record MetsData
         public PlaceInfo Place { get; set; }
         public ModsNote[] Notes { get; set; }
         public string Publisher { get; set; }
+        public ModsName Creator { get; set; }
     }
 
     public record FileData

--- a/Eplicta.Mets/Renderer.cs
+++ b/Eplicta.Mets/Renderer.cs
@@ -305,6 +305,30 @@ public class Renderer
                     modsmods.AppendChild(noteNode);
                 }
             }
+
+            if (_metsData.Mods.Creator != null && !string.IsNullOrEmpty(_metsData.Mods.Creator.DisplayName))
+            {
+                var modsName = doc.CreateElement("mods", "name", ModsNs);
+                modsName.SetAttribute("type", _metsData.Mods.Creator.Type.ToString().ToLower());
+
+                var modsNamePart = doc.CreateElement("mods", "namePart", ModsNs);
+                modsNamePart.InnerText = _metsData.Mods.Creator.DisplayName;
+                modsName.AppendChild(modsNamePart);
+
+                var modsDisplayForm = doc.CreateElement("mods", "displayForm", ModsNs);
+                modsDisplayForm.InnerText = _metsData.Mods.Creator.DisplayName;
+                modsName.AppendChild(modsDisplayForm);
+
+                var modsRole = doc.CreateElement("mods", "role", ModsNs);
+                var modsRoleTerm = doc.CreateElement("mods", "roleTerm", ModsNs);
+                modsRoleTerm.SetAttribute("type", "text");
+                modsRoleTerm.SetAttribute("authority", "marcrelator");
+                modsRoleTerm.InnerText = "creator";
+                modsRole.AppendChild(modsRoleTerm);
+                modsName.AppendChild(modsRole);
+
+                modsmods.AppendChild(modsName);
+            }
         }
 
         //From heres are the file section


### PR DESCRIPTION
Jira: [EP-4540](https://eplicta.atlassian.net/browse/EP-4540). Follow-up (Option B) to EP-4433.

## Why
The post/account author is currently archived as a non-standard `<mods:note type="author display name">`. This adds the canonical MODS representation, `<mods:name>`, so SIPs carry a semantically-correct creator. This is the **Mets (producer + deserializer)** half; Core and FortDocs consume it next.

## What
- `MetsData`: new `ENameType { Personal, Corporate }`, `ModsName { DisplayName, Type }`, and `ModsSectionData.Creator`.
- `Renderer.ModsRenderer`: when `Mods.Creator` is set, emits
  `<mods:name type="corporate"><namePart/><displayForm/><role><roleTerm type="text" authority="marcrelator">creator</roleTerm></role></mods:name>`.
  **Dual-emit** — the existing `mods:note type="author display name"` is unchanged, so current consumers keep working.
- `DeserializedMets`: parses `mods:name` into `Names[]` (with a flat `RoleTerm` accessor) for the consumer side.

## Schema safety
- New theory `CreatorEmitsValidModsNameForAllSchemas` validates a rendered SIP **with `mods:name`** against every MODS schema: FGS-PUBL 1.0 (the per-document SIP gate) and mods-3-0 … mods-3-7. The existing AutoFixture `Basic` theory also covers it.
- `mods:name` is a standard top-level MODS element (optional in every schema), so it does not break validation. The METS-envelope schemas (mets / KB FGS-PUBL / Riksarkivet CSPackageMETS) are unaffected — the change is confined to the MODS section.
- All Mets tests pass: 82 passed / 0 failed / 2 skipped (pre-existing).

## Follow-ups (separate PRs, after this publishes)
- Core: set `Mods.Creator` alongside the note (dual-emit).
- FortDocs: read `mods:name/displayForm`, fall back to the legacy note (dual-read).

## Self-review caveat
Claude wrote this code — limited independent review; worth a human pass before merge.
